### PR TITLE
Improve packaging to deploy a fully fledged package with init script, config & docs (for debian)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-etcd*
+etcd-*
+etcd_*.deb
+!*.conf
+!*.init
+ROOT/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(TARBALL):
 	wget -nv --show-progress -c -O $(TARBALL) $(DOWNLOAD)
 
 $(TARDIR): $(TARBALL)
-	tar xzf $(TARBALL) 
+	tar xzf $(TARBALL)
 
 filetree: $(TARDIR)
 	mkdir -p ROOT/usr/sbin
@@ -54,13 +54,13 @@ etcd_$(VERSION)_amd64.deb: filetree
 		--pre-uninstall debian/prerm \
 		.
 
-etcd_$(VERSION)_amd64.rpm: $(TARDIR) 
+etcd_$(VERSION)_amd64.rpm: $(TARDIR)
 	cd $(TARDIR)/ && \
 	fpm -s dir -t rpm -v $(VERSION) -n $(NAME) -a amd64 \
-	--prefix=/usr/bin \
-        --description "$(DESCRIPTION)" \
-	--url "https://github.com/coreos/etcd" \
-	etcd etcdctl && \
+		--prefix=/usr/bin \
+		--description "$(DESCRIPTION)" \
+		--url "https://github.com/coreos/etcd" \
+		etcd etcdctl && \
 	mv *.rpm ..
 
 .PHONY: clean
@@ -71,4 +71,4 @@ clean:
 deb: $(NAME)_$(VERSION)_amd64.deb
 
 .PHONY: rpm
-rpm: $(NAME)_$(VERSION)_amd64.rpm 
+rpm: $(NAME)_$(VERSION)_amd64.rpm

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 etcd-packages
 =============
 
-Stuff for making etcd packages. 
+A makefile to download etcd and make a package out of it.
 
-A quick makefile to download etcd and make a package out of it.
+For debain & ubuntu based systems an init script and basic config is included in the deployed package.
+
+For rpm based systems the created package is very basic.
 
 ## Requirements
+
 The ever so handy [fpm](https://github.com/jordansissel/fpm)
 
 ## Usage
+
     make deb
+
+or
+
+    ITERATION=custom2 make deb
 

--- a/conf/etcd.conf
+++ b/conf/etcd.conf
@@ -1,0 +1,8 @@
+# etcd configuration file
+
+# sample etcd cluster config
+#export ETCD_INITIAL_CLUSTER_TOKEN="cluster1"
+#export ETCD_INITIAL_CLUSTER="infra1=http://10.1.1.1:2380,infra2=http://10.1.1.2:2380,infra3=http://10.1.1.3:2380"
+#export ETCD_INITIAL_CLUSTER_TOKEN="cluster1"
+#export ETCD_INITIAL_ADVERTISE_PEER_URLS="http://10.1.1.1:2380"
+#export ETCD_LISTEN_PEER_URLS="http://10.1.1.1:2380"

--- a/conf/etcd.conf
+++ b/conf/etcd.conf
@@ -1,4 +1,11 @@
-# etcd configuration file
+#
+# etcd.conf
+#
+# This file will be sourced after the /etc/default/etcd system
+# config file.  You can configure etcd via environment variables
+# from this file.
+#
+# See the documentation in /usr/share/doc/etcd/ for details.
 
 # sample etcd cluster config
 #export ETCD_INITIAL_CLUSTER_TOKEN="cluster1"

--- a/conf/etcd.init
+++ b/conf/etcd.init
@@ -1,0 +1,126 @@
+#!/bin/sh
+# Debian SysV init script for etcd
+# Jinn Koriech <https://github.com/jinnko/etcd-packages>
+### BEGIN INIT INFO
+# Provides:          etcd
+# Required-Start:    hostname $local_fs $remote_fs $syslog $named $network $time
+# Required-Stop:     $local_fs $remote_fs $syslog $named $network
+# Should-Start:      udev mdadm-raid lvm2 cryptdisks-early iptables firehol shorewall
+# Should-Stop:       
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: start and stop the etcd key-value store
+# Description:       A highly-available key-value store for shared configuration and service discovery.
+### END INIT INFO
+
+NAME="etcd"
+DAEMON="/usr/sbin/etcd"
+DESC="etcd key-value store for shared configuration and service discovery daemon"
+NICE="0"
+
+test -x $DAEMON || exit 5
+
+. /lib/lsb/init-functions
+
+ETCD_LOGFILE="/var/log/etcd/etcd.log"
+ETCD_PIDFILE="/var/run/etcd.pid"
+ETCD_USER="etcd"
+ETCD_GROUP="etcd"
+
+# Ensure log is writable
+[ -d "$(dirname ${ETCD_LOGFILE})" ] || mkdir "$(dirname ${ETCD_LOGFILE})"
+if [ "$(/usr/bin/stat -t $(dirname $ETCD_LOGFILE) --printf=%u)" != "$ETCD_USER" ]; then
+  chown $ETCD_USER:$ETCD_GROUP $(dirname $ETCD_LOGFILE)
+fi
+
+# etcd config via environment variables
+# - first local init script defaults
+# - then system defaults
+# - then user config
+ETCD_NAME="$(hostname -s)"
+ETCD_DATA_DIR="/var/lib/etcd/${ETCD_NAME}"
+test -f /etc/default/etcd && . /etc/default/etcd
+test -f /etc/etcd.conf && . /etc/etcd.conf
+
+is_running() {
+  # Returned status corresponds to init-functions script
+  # 0 = process exists
+  # 1 = pidfile exists, but process doesn't
+  # 4 = no pidfile exists
+  if [ -r "$ETCD_PIDFILE" ]; then
+    kill -0 $(cat $ETCD_PIDFILE)
+    return $?
+  else
+    return 4
+  fi
+}
+
+status() {
+  is_running; ret=$?
+  if [ $ret -eq 0 ]; then
+    echo "$NAME is running."
+  elif [ $ret -eq 1 ]; then
+    echo "Pidfile found, but process isn't running."
+  elif [ $ret -eq 4 ]; then
+    echo "$NAME not running."
+  else
+    echo "Unknown status: $ret"
+  fi
+  exit $ret
+}
+
+start() {
+  if is_running; then
+    echo "$NAME is already running."
+    exit 0
+  fi
+  log_begin_msg "Starting $NAME: "
+
+  if [ ! -d "$ETCD_DATA_DIR" ]; then
+    mkdir -p "${ETCD_DATA_DIR}"
+    chown $ETCD_USER:$ETCD_GROUP "${ETCD_DATA_DIR}"
+    chmod 0700 "${ETCD_DATA_DIR}"
+  fi
+
+  /sbin/start-stop-daemon --start --nicelevel $NICE \
+    --chdir "$ETCD_DATA_DIR" --chuid $ETCD_USER:$ETCD_GROUP \
+    --background --pidfile "$ETCD_PIDFILE" --make-pidfile \
+    --exec $DAEMON --no-close -- > $ETCD_LOGFILE 2>&1
+  RETVAL=$?
+  if [ $RETVAL -eq 0 ]; then
+    log_success_msg "started"
+  else
+    log_failure_msg "failed"
+  fi
+  return $RETVAL
+}
+
+stop() {
+  is_running; ret=$?
+  if [ $ret -ne 0 ]; then
+    echo "Not stopping $NAME because it isn't running."
+    exit 0
+  fi
+  log_begin_msg "Stopping $NAME: "
+
+  killproc -p "$ETCD_PIDFILE" "$DAEMON"
+  RETVAL=$?
+  if [ $RETVAL -eq 0 ]; then
+    log_success_msg "stopped"
+    rm "${ETCD_PIDFILE}"
+  else
+    log_failure_msg "failed"
+  fi
+  return $RETVAL
+}
+
+restart() {
+  stop
+  sleep 1
+  start
+}
+
+$1 || {
+  echo "Usage: $0 {start|stop|restart|status}"
+  RETVAL=1
+}

--- a/conf/etcd_default.conf
+++ b/conf/etcd_default.conf
@@ -1,0 +1,4 @@
+# etcd configuration file
+
+export ETCD_NAME="$(hostname -s)"
+export ETCD_DATA_DIR="/var/lib/etcd/${ETCD_NAME}"

--- a/conf/etcd_local.conf
+++ b/conf/etcd_local.conf
@@ -1,9 +1,0 @@
-#
-# etcd.conf
-#
-# This file will be sourced after the /etc/default/etcd system
-# config file.  You can configure etcd via environment variables
-# from this file.
-# See the documentation in /usr/share/doc/etcd/ for details.
-
-#export ETCD_NAME="$(hostname)"

--- a/conf/etcd_local.conf
+++ b/conf/etcd_local.conf
@@ -1,0 +1,9 @@
+#
+# etcd.conf
+#
+# This file will be sourced after the /etc/default/etcd system
+# config file.  You can configure etcd via environment variables
+# from this file.
+# See the documentation in /usr/share/doc/etcd/ for details.
+
+#export ETCD_NAME="$(hostname)"

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+USER=etcd
+GROUP=etcd
+HOMEDIR=/var/lib/etcd
+
+addgroup -q --system ${GROUP}
+adduser -q --system --home ${HOMEDIR} --ingroup ${GROUP} --disabled-password --disabled-login ${USER}
+
+chown ${USER}:${GROUP} ${HOMEDIR}
+
+service etcd start

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if service etcd status; then
+  service etcd stop
+fi


### PR DESCRIPTION
- Bump packaged version to v2.0.5 upstream
- Make wget output less verbose
- Create a file tree with /etc and /usr files
- Introduce an init script and config files
- Package for debian with awareness of configs, init script and data dir
- Package includes postinst and prerm scripts for graceful handling
- Make the README relevant to the changes introduced