### PR TITLE
default config file change + Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ default: deb
 package: deb
 
 $(TARBALL):
-	wget -nv --show-progress -c -O $(TARBALL) $(DOWNLOAD)
+	wget -nv --progress=bar -c -O $(TARBALL) $(DOWNLOAD)
 
 $(TARDIR): $(TARBALL)
 	tar xzf $(TARBALL)

--- a/conf/etcd.conf
+++ b/conf/etcd.conf
@@ -10,6 +10,5 @@
 # sample etcd cluster config
 #export ETCD_INITIAL_CLUSTER_TOKEN="cluster1"
 #export ETCD_INITIAL_CLUSTER="infra1=http://10.1.1.1:2380,infra2=http://10.1.1.2:2380,infra3=http://10.1.1.3:2380"
-#export ETCD_INITIAL_CLUSTER_TOKEN="cluster1"
 #export ETCD_INITIAL_ADVERTISE_PEER_URLS="http://10.1.1.1:2380"
 #export ETCD_LISTEN_PEER_URLS="http://10.1.1.1:2380"


### PR DESCRIPTION
The two minor changes was needed to get it working on ubuntu trusty (14.04) server.   duplicate token line was causing etcd not picking up the rest of the config file, defaulting to only listening to 127.0.0.1 instead of binding to the addr  and peer-addr in the config file

wget was failing due to the --show-progress switch